### PR TITLE
UV座標を0から1の数値にノーマライズする。

### DIFF
--- a/Assets/MeshDeleterWithTexture/Editor/MeshDeleterWithTexture.cs
+++ b/Assets/MeshDeleterWithTexture/Editor/MeshDeleterWithTexture.cs
@@ -1231,6 +1231,11 @@ namespace Gatosyocora.MeshDeleterWithTexture
 
             if (uvs.Count() <= 0) return null;
 
+            for (int i = 0; i < uvs.Length; i++)
+            {
+                uvs[i] = new Vector2(Mathf.Repeat(uvs[i].x, 1.0f), Mathf.Repeat(uvs[i].y, 1.0f));
+            }
+
             ComputeShader cs = Instantiate(Resources.Load<ComputeShader>("getUVMap")) as ComputeShader;
             int kernel = cs.FindKernel("CSMain");
 


### PR DESCRIPTION
モデルによってはUV座標が０～１間の数値でない場合があります。
その場合メッシュ塗りつぶし画面にUVマップが表示されません。

このパッチで正常に表示されるようになります。
⊿S.I.N様で販売されている３Dモデル「Reeva」で確認済みです。
